### PR TITLE
Updating CMakeLists.txt to allow CMake to use either CMAKE_INSTALL_PREFIX or CPACK_INSTALL_PREFIX

### DIFF
--- a/cpp/kiss_icp/core/CMakeLists.txt
+++ b/cpp/kiss_icp/core/CMakeLists.txt
@@ -27,5 +27,5 @@ target_link_libraries(core PUBLIC Eigen3::Eigen tsl::robin_map TBB::tbb Sophus::
 set_global_target_properties(core)
 
 
-install( TARGETS core DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
-install( FILES Registration.hpp Deskew.hpp VoxelHashMap.hpp Preprocessing.hpp Threshold.hpp DESTINATION ${CMAKE_INSTALL_PREFIX}/include/kiss_icp/core )
+install( TARGETS core DESTINATION lib)
+install( FILES Registration.hpp Deskew.hpp VoxelHashMap.hpp Preprocessing.hpp Threshold.hpp DESTINATION include/kiss_icp/core )

--- a/cpp/kiss_icp/metrics/CMakeLists.txt
+++ b/cpp/kiss_icp/metrics/CMakeLists.txt
@@ -27,5 +27,5 @@ target_link_libraries(metrics PUBLIC Eigen3::Eigen)
 set_global_target_properties(metrics)
 
 
-install( TARGETS metrics DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
-install( FILES Metrics.hpp DESTINATION ${CMAKE_INSTALL_PREFIX}/include/kiss_icp )
+install( TARGETS metrics DESTINATION lib)
+install( FILES Metrics.hpp DESTINATION include/kiss_icp )

--- a/cpp/kiss_icp/pipeline/CMakeLists.txt
+++ b/cpp/kiss_icp/pipeline/CMakeLists.txt
@@ -27,5 +27,5 @@ target_sources(pipeline PRIVATE KissICP.cpp)
 target_link_libraries(pipeline PUBLIC kiss_icp::core)
 set_global_target_properties(pipeline)
 
-install( TARGETS pipeline DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
-install( FILES KissICP.hpp DESTINATION ${CMAKE_INSTALL_PREFIX}/include/kiss_icp )
+install( TARGETS pipeline DESTINATION lib)
+install( FILES KissICP.hpp DESTINATION include/kiss_icp )


### PR DESCRIPTION
Allow CMake to use either CMAKE_INSTALL_PREFIX or CPACK_INSTALL_PREFIX
in pipeline, core and metrics